### PR TITLE
DOI-882 OpenEtherum version, configuration file

### DIFF
--- a/ewc-affiliate/openethereum/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-centos-7-production.sh
@@ -5,8 +5,8 @@ set -e
 set -o errexit
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -176,7 +176,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -255,7 +255,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-/usr/local/bin/lynis audit system 
+/usr/local/bin/lynis audit system
 
 
 # Print install summary
@@ -274,7 +274,7 @@ cat install-summary.txt
 }
 
 ## Files that get created
-      
+
 
 writeDockerCompose() {
 cat > docker-compose.yml << 'EOF'
@@ -288,10 +288,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -416,13 +416,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -434,6 +428,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -450,13 +445,12 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/ewc-affiliate/openethereum/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-centos-7-production.sh
@@ -169,7 +169,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 

--- a/ewc-affiliate/openethereum/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-debian-9.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -186,7 +186,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -262,7 +262,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-lynis audit system 
+lynis audit system
 
 
 # Print install summary
@@ -281,7 +281,7 @@ cat install-summary.txt
 }
 
 ## Files that get created
-      
+
 
 writeDockerCompose() {
 cat > docker-compose.yml << 'EOF'
@@ -295,10 +295,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -421,13 +421,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -439,6 +433,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -455,13 +450,12 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/ewc-affiliate/openethereum/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-debian-9.x-production.sh
@@ -179,7 +179,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 

--- a/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
@@ -455,7 +455,7 @@ max_pending_peers = 64
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
@@ -179,7 +179,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 

--- a/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/openethereum/install-validator-ubuntu-server-18.04-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -186,7 +186,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -262,7 +262,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-lynis audit system 
+lynis audit system
 
 
 # Print install summary
@@ -281,7 +281,7 @@ cat install-summary.txt
 }
 
 ## Files that get created
-      
+
 
 writeDockerCompose() {
 cat > docker-compose.yml << 'EOF'
@@ -295,10 +295,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -421,13 +421,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -439,6 +433,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -455,7 +450,6 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"

--- a/volta-affiliate/openethereum/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-centos-7-volta.sh
@@ -5,8 +5,8 @@ set -e
 set -o errexit
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -176,7 +176,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -255,7 +255,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-/usr/local/bin/lynis audit system 
+/usr/local/bin/lynis audit system
 
 
 # Print install summary
@@ -287,10 +287,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -415,13 +415,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -433,6 +427,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -449,13 +444,12 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/volta-affiliate/openethereum/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-centos-7-volta.sh
@@ -169,7 +169,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 

--- a/volta-affiliate/openethereum/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-debian-9.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -186,7 +186,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -262,7 +262,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-lynis audit system 
+lynis audit system
 
 
 # Print install summary
@@ -294,10 +294,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -420,13 +420,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -438,6 +432,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -454,13 +449,12 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/volta-affiliate/openethereum/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-debian-9.x-volta.sh
@@ -179,7 +179,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 

--- a/volta-affiliate/openethereum/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-ubuntu-server-18.04-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-PARITY_VERSION="parity/parity:v2.5.13-stable"
-PARITY_CHKSUM="sha256:36be05aeb6426b5615e2d6b71c9590dbc4a4d03ae7bcfa53edefdaeef28d3f41"
+PARITY_VERSION="openethereum/openethereum:v3.2.5"
+PARITY_CHKSUM="sha256:5456244fb93fa6100e83b6dbebb9bc6f43d729522554da065b28967084bb7ee3"
 
 PARITYTELEMETRY_VERSION="1.1.0"
 PARITYTELEMETRY_CHKSUM="sha256:00e3a14c5e9c6629eedfcece86e12599f5813c0f2fc075689efa1233aa0cfef7"
@@ -186,7 +186,7 @@ docker run -d --name parity-keygen \
 # Wait for parity to sort itself out
 sleep 20
 
-generate_account_data() 
+generate_account_data()
 {
 cat << EOF
 { "method": "parity_newAccountFromSecret", "params": ["$KEY_SEED","$PASSWORD"], "id": 1, "jsonrpc": "2.0" }
@@ -262,7 +262,7 @@ wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
 tar xvzf lynis-2.7.1.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/local/bin/lynis
-lynis audit system 
+lynis audit system
 
 
 # Print install summary
@@ -294,10 +294,10 @@ services:
       --nat extip:${EXTERNAL_IP}
     volumes:
       - ./config:/parity/config:ro
-      - ./chain-data:/home/parity/.local/share/io.parity.ethereum/
+      - ./chain-data:/home/openethereum/.local/share/io.parity.ethereum/
       - ./.secret:/parity/authority.pwd:ro
     ports:
-      - 30303:30303 
+      - 30303:30303
       - 30303:30303/udp
       - 127.0.0.1:8545:8545
 
@@ -420,13 +420,7 @@ function writeParityConfig() {
 cat > config/parity-non-signing.toml << EOF
 [parity]
 chain = "/parity/config/chainspec.json"
-auto_update = "none"
-release_track = "current"
-no_download = true
 no_persistent_txqueue = true
-
-[ui]
-disable = true
 
 [rpc]
 disable = false
@@ -438,6 +432,7 @@ apis = ["eth", "net", "parity", "web3"]
 [websockets]
 disable = false
 interface = "0.0.0.0"
+port = 8546
 
 [ipc]
 disable = true
@@ -454,13 +449,12 @@ warp = false
 allow_ips = "all"
 snapshot_peers = 0
 max_pending_peers = 64
-no_serve_light = true
 
 [footprint]
 db_compaction = "ssd"
 
 [snapshots]
-disable_periodic = true
+enable = false
 
 [mining]
 force_sealing = true

--- a/volta-affiliate/openethereum/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/openethereum/install-validator-ubuntu-server-18.04-volta.sh
@@ -179,7 +179,7 @@ chown 1000:1000 .secret
 # Launch oneshot docker
 docker run -d --name parity-keygen \
     -p 127.0.0.1:8545:8545 \
-    -v ${XPATH}/chain-data/:/home/parity/.local/share/io.parity.ethereum/ \
+    -v ${XPATH}/chain-data/:/home/openethereum/.local/share/io.parity.ethereum/ \
     -v ${XPATH}/config:/parity/config:ro ${PARITY_VERSION} \
     --config /parity/config/parity-non-signing.toml --jsonrpc-apis=parity_accounts
 


### PR DESCRIPTION
- Update OpenEthereum (Ex-Parity client) version
  -  `parity/parity:v2.5.13-stable` to `openethereum/openethereum:v3.2.5`
- Update configuration file to align with OpenEthereum (parity-signing.toml, parity-non-signing.toml)
- Update path for docker-compose to align with OpenEthereum