### PR TITLE
update: nethermind version and client configurations

### DIFF
--- a/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -429,7 +429,7 @@ cat > configs/energyweb.cfg << EOF
     "GenesisHash": "0x0b6d3e680af2fc525392c720666cce58e3d8e6fe75ba4b48cb36bcc69039229b",
     "BaseDbPath": "nethermind_db/energyweb",
     "LogFileName": "energyweb.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -441,7 +441,7 @@ cat > configs/energyweb.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -450,9 +450,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0x83c49ea5ef801f1337e14de8855d6b0373c8ffb89733cbb4f98bebe683f1e8a2",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668696908",
+    "PivotNumber": 23570000,
+    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
+    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -445,14 +445,11 @@ cat > configs/energyweb.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23570000,
-    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
-    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
+    "PivotNumber": 23850000,
+    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
+    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -437,7 +437,7 @@ cat > configs/energyweb.cfg << EOF
     "GenesisHash": "0x0b6d3e680af2fc525392c720666cce58e3d8e6fe75ba4b48cb36bcc69039229b",
     "BaseDbPath": "nethermind_db/energyweb",
     "LogFileName": "energyweb.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -449,7 +449,7 @@ cat > configs/energyweb.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -458,9 +458,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0x83c49ea5ef801f1337e14de8855d6b0373c8ffb89733cbb4f98bebe683f1e8a2",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668696908",
+    "PivotNumber": 23570000,
+    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
+    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -453,14 +453,11 @@ cat > configs/energyweb.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23570000,
-    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
-    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
+    "PivotNumber": 23850000,
+    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
+    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -446,14 +446,11 @@ cat > configs/energyweb.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23570000,
-    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
-    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
+    "PivotNumber": 23850000,
+    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
+    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -426,9 +426,9 @@ cat > configs/energyweb.cfg << EOF
     "WebSocketsEnabled": true,
     "StoreReceipts" : true,
     "IsMining": true,
-    "PivotNumber": 22570000,
-    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
-    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
+    "ChainSpecPath": "chainspec/energyweb.json",
+    "GenesisHash": "0x0b6d3e680af2fc525392c720666cce58e3d8e6fe75ba4b48cb36bcc69039229b",
+    "BaseDbPath": "nethermind_db/energyweb",
     "LogFileName": "energyweb.logs.txt",
     "MemoryHint": 768000000
   },

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -452,8 +452,8 @@ cat > configs/energyweb.cfg << EOF
   "Sync": {
     "FastSync": true,
     "PivotNumber": 23570000,
-    "PivotHash": "0xaa15525206343f64bac5ce501c2324d5a477d69445610d417e34d34220a67d31",
-    "PivotTotalDifficulty": "3110180833657377556055243911926361452377382254",
+    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
+    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -426,11 +426,11 @@ cat > configs/energyweb.cfg << EOF
     "WebSocketsEnabled": true,
     "StoreReceipts" : true,
     "IsMining": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0x83c49ea5ef801f1337e14de8855d6b0373c8ffb89733cbb4f98bebe683f1e8a2",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668696908",
+    "PivotNumber": 22570000,
+    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
+    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
     "LogFileName": "energyweb.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -442,7 +442,7 @@ cat > configs/energyweb.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -451,7 +451,7 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 9140000,
+    "PivotNumber": 23570000,
     "PivotHash": "0xaa15525206343f64bac5ce501c2324d5a477d69445610d417e34d34220a67d31",
     "PivotTotalDifficulty": "3110180833657377556055243911926361452377382254",
     "FastBlocks" : true,

--- a/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -452,14 +452,11 @@ cat > configs/energyweb.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23570000,
-    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
-    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
+    "PivotNumber": 23850000,
+    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
+    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -436,7 +436,7 @@ cat > configs/energyweb.cfg << EOF
     "GenesisHash": "0x0b6d3e680af2fc525392c720666cce58e3d8e6fe75ba4b48cb36bcc69039229b",
     "BaseDbPath": "nethermind_db/energyweb",
     "LogFileName": "energyweb.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -448,7 +448,7 @@ cat > configs/energyweb.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -457,9 +457,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0x83c49ea5ef801f1337e14de8855d6b0373c8ffb89733cbb4f98bebe683f1e8a2",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668696908",
+    "PivotNumber": 23570000,
+    "PivotHash": "0xe253a21aca67b312f20c405fdef0d90c8c7894517f4c5da20e17d6cfea303d8a",
+    "PivotTotalDifficulty": "8020455388326519583831739497166776743658171427",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -443,14 +443,11 @@ cat > configs/volta.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22570000,
-    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
-    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
+    "PivotNumber": 22820000,
+    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
+    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -427,7 +427,7 @@ cat > configs/volta.cfg << EOF
     "GenesisHash": "0xebd8b413ca7b7f84a8dd20d17519ce2b01954c74d94a0a739a3e416abe0e43e5",
     "BaseDbPath": "nethermind_db/volta",
     "LogFileName": "volta.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -439,7 +439,7 @@ cat > configs/volta.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -448,9 +448,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0xf3906f1a1aa8eea0bee34590db4b84b17893aa070fa8b1e3e207a4eb2f4092ed",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668697622",
+    "PivotNumber": 22570000,
+    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
+    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -450,14 +450,11 @@ cat > configs/volta.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22570000,
-    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
-    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
+    "PivotNumber": 22820000,
+    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
+    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -434,7 +434,7 @@ cat > configs/volta.cfg << EOF
     "GenesisHash": "0xebd8b413ca7b7f84a8dd20d17519ce2b01954c74d94a0a739a3e416abe0e43e5",
     "BaseDbPath": "nethermind_db/volta",
     "LogFileName": "volta.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -446,7 +446,7 @@ cat > configs/volta.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -455,9 +455,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0xf3906f1a1aa8eea0bee34590db4b84b17893aa070fa8b1e3e207a4eb2f4092ed",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668697622",
+    "PivotNumber": 22570000,
+    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
+    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -444,14 +444,11 @@ cat > configs/volta.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22570000,
-    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
-    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
+    "PivotNumber": 22820000,
+    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
+    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -428,7 +428,7 @@ cat > configs/volta.cfg << EOF
     "GenesisHash": "0xebd8b413ca7b7f84a8dd20d17519ce2b01954c74d94a0a739a3e416abe0e43e5",
     "BaseDbPath": "nethermind_db/volta",
     "LogFileName": "volta.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -440,7 +440,7 @@ cat > configs/volta.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -449,9 +449,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0xf3906f1a1aa8eea0bee34590db4b84b17893aa070fa8b1e3e207a4eb2f4092ed",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668697622",
+    "PivotNumber": 22570000,
+    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
+    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
-NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
+export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
+NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -451,14 +451,11 @@ cat > configs/volta.cfg << EOF
     "Host": "0.0.0.0",
     "Port": 8545
   },
-  "Db": {
-    "CacheIndexAndFilterBlocks": false
-  },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22570000,
-    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
-    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
+    "PivotNumber": 22820000,
+    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
+    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000

--- a/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.11.7"
-NETHERMIND_CHKSUM="sha256:c0e6c57336d0fc8c4f3459b1c94d1d89524b76596c7b2fead5d9b00a8d0a7705"
+export NETHERMIND_VERSION="nethermind/nethermind:1.17.4"
+NETHERMIND_CHKSUM="sha256:299497fc3bb279612cb0aed4b7f08e7abc5396bffdbce4899fd0b0c84302a45b"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -435,7 +435,7 @@ cat > configs/volta.cfg << EOF
     "GenesisHash": "0xebd8b413ca7b7f84a8dd20d17519ce2b01954c74d94a0a739a3e416abe0e43e5",
     "BaseDbPath": "nethermind_db/volta",
     "LogFileName": "volta.logs.txt",
-    "MemoryHint": 256000000
+    "MemoryHint": 768000000
   },
   "Network": {
     "DiscoveryPort": 30303,
@@ -447,7 +447,7 @@ cat > configs/volta.cfg << EOF
   },
   "JsonRpc": {
     "Enabled": true,
-    "TracerTimeout": 20000,
+    "Timeout": 20000,
     "Host": "0.0.0.0",
     "Port": 8545
   },
@@ -456,9 +456,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 11610000,
-    "PivotHash": "0xf3906f1a1aa8eea0bee34590db4b84b17893aa070fa8b1e3e207a4eb2f4092ed",
-    "PivotTotalDifficulty": "3950678279952095560809779192282828934668697622",
+    "PivotNumber": 22570000,
+    "PivotHash": "0x702b56e3f6ece178c3fcadc4c10c66088aa17ef282df212c15fb91a50a4306be",
+    "PivotTotalDifficulty": "7680173021405581120368364889735008532203175805",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000


### PR DESCRIPTION
- Use nethermind client v1.18.0
- Update configurations, remove deprecated config
  - https://docs.nethermind.io/nethermind/ethereum-client/configuration/jsonrpc 
- Fix: Script for RHEL dist
- Remove DB conf, which is default in nethermind configuration. 
```
 "Db": {
    "CacheIndexAndFilterBlocks": false
  },
```
