### PR TITLE
update: TargetBlockGasLimit in Blocks module. TargetBlockGasLimit fro…

### DIFF
--- a/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
@@ -477,7 +477,7 @@ cat > configs/energyweb.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
@@ -485,7 +485,7 @@ cat > configs/energyweb.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -478,7 +478,7 @@ cat > configs/energyweb.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
@@ -484,7 +484,7 @@ cat > configs/energyweb.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
@@ -475,7 +475,7 @@ cat > configs/volta.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
@@ -482,7 +482,7 @@ cat > configs/volta.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-rhel-7.x-volta.sh
@@ -476,7 +476,7 @@ cat > configs/volta.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {

--- a/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
@@ -483,7 +483,7 @@ cat > configs/volta.cfg << EOF
     "ServerUrl": "http://localhost:5341",
     "ApiKey": ""
   },
-  "Mining": {
+  "Blocks": {
     "TargetBlockGasLimit": $BLOCK_GAS
   },
   "Aura": {


### PR DESCRIPTION
- Update TargetBlockGasLimit in Blocks module. TargetBlockGasLimit from Mining module is deprecated since v1.14.6
- https://docs.nethermind.io/nethermind/ethereum-client/configuration/mining
- https://docs.nethermind.io/nethermind/ethereum-client/configuration/blocks
