### PR TITLE
Update nethermind v1.25.4 and fix lynis package version

### DIFF
--- a/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-centos-7-production.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -39,13 +39,13 @@ systemctl stop firewalld
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -61,7 +61,7 @@ until [[ -n "$COMPANY_NAME" ]]; do
 	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
@@ -72,7 +72,7 @@ EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Ente
 NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -117,7 +117,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf-$TELEGRAF_VERSION-1.x8
 TG_CHK="$(sha256sum telegraf-$TELEGRAF_VERSION-1.x86_64.rpm)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 yum -y localinstall telegraf-$TELEGRAF_VERSION-1.x86_64.rpm
@@ -144,14 +144,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -179,7 +179,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -192,7 +192,7 @@ EOF
 echo "Waiting 45 sec for nethermind to come up and create an account..."
 sleep 45
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
@@ -204,7 +204,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -212,7 +212,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -224,7 +224,7 @@ docker-compose up -d
 
 echo "Waiting 45 sec for nethermind to come up and generate the enode..."
 sleep 45
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -251,30 +251,31 @@ iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -j FILTERS
 iptables -P INPUT DROP
 
-iptables -A DOCKER-USER -i $NETIF -j FILTERS
+iptables -A DOCKER-USER -i "$NETIF" -j FILTERS
 iptables -A DOCKER-USER -j RETURN
 service iptables save
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
-
 
 # END OF MAIN
 }
@@ -447,9 +448,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23850000,
-    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
-    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
+    "PivotNumber": 26940000,
+    "PivotHash": "0x8835983de9578a4355313afd2a43d8eada6f2a4ddbd9c51da103e0d5f53c4d8b",
+    "PivotTotalDifficulty": "9167206964850082205703311924211835616257898274",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -482,6 +483,12 @@ cat > configs/energyweb.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-debian-9.x-production.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -51,13 +51,13 @@ apt-get install -y curl net-tools dnsutils expect jq iptables-persistent debsums
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -73,7 +73,7 @@ until [[ -n "$COMPANY_NAME" ]]; do
 	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
@@ -84,7 +84,7 @@ EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Ente
 NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -128,7 +128,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf_$TELEGRAF_VERSION-1_am
 TG_CHK="$(sha256sum telegraf_$TELEGRAF_VERSION-1_amd64.deb)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 dpkg -i telegraf_$TELEGRAF_VERSION-1_amd64.deb
@@ -155,14 +155,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -190,7 +190,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -203,8 +203,7 @@ EOF
 echo "Waiting 45 sec for nethermind to come up and create an account..."
 sleep 45
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
-
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
 INFLUX_PASS="$(openssl rand -hex 16)"
@@ -215,7 +214,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -223,7 +222,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -235,8 +234,7 @@ docker-compose up -d
 
 echo "Waiting 45 sec for nethermind to come up and generate the enode..."
 sleep 45
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
-
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
 service telegraf restart
@@ -260,30 +258,31 @@ iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -j FILTERS
 iptables -P INPUT DROP
 
-iptables -A DOCKER-USER -i $NETIF -j FILTERS
+iptables -A DOCKER-USER -i "$NETIF" -j FILTERS
 iptables -A DOCKER-USER -j RETURN
 iptables-save > /etc/iptables/rules.v4
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
-
 
 # END OF MAIN
 }
@@ -455,9 +454,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23850000,
-    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
-    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
+    "PivotNumber": 26940000,
+    "PivotHash": "0x8835983de9578a4355313afd2a43d8eada6f2a4ddbd9c51da103e0d5f53c4d8b",
+    "PivotTotalDifficulty": "9167206964850082205703311924211835616257898274",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -490,6 +489,12 @@ cat > configs/energyweb.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/ewc-affiliate/nethermind/install-validator-oracle-8.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-oracle-8.x-production.sh
@@ -6,8 +6,8 @@ set -o errexit
 export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.21.1"
-NETHERMIND_CHKSUM="sha256:63f626f9c008ffb4f49cc8b0078234ece5ff7f60599957c41633c8575dbf8984"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -256,8 +256,8 @@ service iptables save
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
@@ -447,9 +447,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 24590000,
-    "PivotHash": "0x4c5bec0e71e1d399f48de1ddd6963273e02bccef0593ce26294ef5cdaee8f619",
-    "PivotTotalDifficulty": "8367543402585876816564381596747180319341185475",
+    "PivotNumber": 26940000,
+    "PivotHash": "0x8835983de9578a4355313afd2a43d8eada6f2a4ddbd9c51da103e0d5f53c4d8b",
+    "PivotTotalDifficulty": "9167206964850082205703311924211835616257898274",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -482,6 +482,12 @@ cat > configs/energyweb.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-rhel-7.x-production.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -39,13 +39,13 @@ systemctl stop firewalld
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -61,7 +61,7 @@ until [[ -n "$COMPANY_NAME" ]]; do
 	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
@@ -72,7 +72,7 @@ EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Ente
 NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -118,7 +118,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf-$TELEGRAF_VERSION-1.x8
 TG_CHK="$(sha256sum telegraf-$TELEGRAF_VERSION-1.x86_64.rpm)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 yum -y localinstall telegraf-$TELEGRAF_VERSION-1.x86_64.rpm
@@ -145,14 +145,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -180,7 +180,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -193,7 +193,7 @@ EOF
 echo "Waiting 45 sec for nethermind to come up and create an account..."
 sleep 45
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
@@ -205,7 +205,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -213,7 +213,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -225,7 +225,7 @@ docker-compose up -d
 
 echo "Waiting 45 sec for nethermind to come up and generate the enode..."
 sleep 45
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -252,30 +252,31 @@ iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -j FILTERS
 iptables -P INPUT DROP
 
-iptables -A DOCKER-USER -i $NETIF -j FILTERS
+iptables -A DOCKER-USER -i "$NETIF" -j FILTERS
 iptables -A DOCKER-USER -j RETURN
 service iptables save
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
-
 
 # END OF MAIN
 }
@@ -448,9 +449,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23850000,
-    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
-    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
+    "PivotNumber": 26940000,
+    "PivotHash": "0x8835983de9578a4355313afd2a43d8eada6f2a4ddbd9c51da103e0d5f53c4d8b",
+    "PivotTotalDifficulty": "9167206964850082205703311924211835616257898274",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -483,6 +484,12 @@ cat > configs/energyweb.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
+++ b/ewc-affiliate/nethermind/install-validator-ubuntu-server-18.04-production.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -51,13 +51,13 @@ apt-get install -y curl net-tools dnsutils expect jq iptables-persistent debsums
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -73,7 +73,7 @@ until [[ -n "$COMPANY_NAME" ]]; do
 	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
@@ -84,7 +84,7 @@ EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Ente
 NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -128,7 +128,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf_$TELEGRAF_VERSION-1_am
 TG_CHK="$(sha256sum telegraf_$TELEGRAF_VERSION-1_amd64.deb)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 dpkg -i telegraf_$TELEGRAF_VERSION-1_amd64.deb
@@ -155,14 +155,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -176,6 +176,7 @@ mkdir logs
 mkdir keystore
 
 echo "Fetch Chainspec..."
+# TODO: replace with chainspec location
 wget $CHAINSPEC_URL -O chainspec/energyweb.json
 
 echo "Creating Account..."
@@ -189,7 +190,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -202,8 +203,7 @@ EOF
 echo "Waiting 45 sec for nethermind to come up and create an account..."
 sleep 45
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
-
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
 INFLUX_PASS="$(openssl rand -hex 16)"
@@ -214,7 +214,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -222,7 +222,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -234,7 +234,7 @@ docker-compose up -d
 
 echo "Waiting 45 sec for nethermind to come up and generate the enode..."
 sleep 45
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -265,24 +265,25 @@ iptables-save > /etc/iptables/rules.v4
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
-
 
 # END OF MAIN
 }
@@ -454,9 +455,9 @@ cat > configs/energyweb.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23850000,
-    "PivotHash": "0xc5d6f496e929f6bdda9bbb08c6cef82f5aac1ae536afa1c8c09b53c42d8bebda",
-    "PivotTotalDifficulty": "8115734451064382353601484387247671842865272564",
+    "PivotNumber": 26940000,
+    "PivotHash": "0x8835983de9578a4355313afd2a43d8eada6f2a4ddbd9c51da103e0d5f53c4d8b",
+    "PivotTotalDifficulty": "9167206964850082205703311924211835616257898274",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -489,6 +490,12 @@ cat > configs/energyweb.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-centos-7-volta.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -37,13 +37,13 @@ systemctl stop firewalld
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -56,21 +56,21 @@ HOMEDIR=$(pwd)
 whiptail --backtitle="EWF Genesis Node Installer" --title "Confirm Home Directory" --yesno "Is $(pwd) the normal users home directory?" 8 60
 
 until [[ -n "$COMPANY_NAME" ]]; do
-	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
+	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 "$COMPANY_NAME" --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
         fi
 done
 
-EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts public IP" 8 78 $EXTERNAL_IP --title "Connectivity" 3>&1 1>&2 2>&3)
-NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
+EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts public IP" 8 78 "$EXTERNAL_IP" --title "Connectivity" 3>&1 1>&2 2>&3)
+NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 "$NETIF" --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -115,7 +115,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf-$TELEGRAF_VERSION-1.x8
 TG_CHK="$(sha256sum telegraf-$TELEGRAF_VERSION-1.x86_64.rpm)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 yum -y localinstall telegraf-$TELEGRAF_VERSION-1.x86_64.rpm
@@ -142,14 +142,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -177,7 +177,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -190,7 +190,7 @@ EOF
 echo "Waiting 30 sec for nethermind to come up and create an account..."
 sleep 30
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
@@ -202,7 +202,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -210,7 +210,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -222,7 +222,7 @@ docker-compose up -d
 
 echo "Waiting 15 sec for nethermind to come up and generate the enode..."
 sleep 15
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -445,9 +445,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22820000,
-    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
-    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
+    "PivotNumber": 26680000,
+    "PivotHash": "0x038403ed7351bf180066ea7b6396daec13e6bb13163334ac9fab8ee3de19d471",
+    "PivotTotalDifficulty": "9078733549450638205202834526279575881277928465",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -480,6 +480,12 @@ cat > configs/volta.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-debian-9.x-volta.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -49,13 +49,13 @@ apt-get install -y curl net-tools dnsutils expect jq iptables-persistent debsums
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -68,21 +68,21 @@ HOMEDIR=$(pwd)
 whiptail --backtitle="EWF Genesis Node Installer" --title "Confirm Home Directory" --yesno "Is $(pwd) the normal users home directory?" 8 60
 
 until [[ -n "$COMPANY_NAME" ]]; do
-	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
+	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 "$COMPANY_NAME" --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
         fi
 done
 
-EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts public IP" 8 78 $EXTERNAL_IP --title "Connectivity" 3>&1 1>&2 2>&3)
-NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
+EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts public IP" 8 78 "$EXTERNAL_IP" --title "Connectivity" 3>&1 1>&2 2>&3)
+NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 "$NETIF" --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -126,7 +126,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf_$TELEGRAF_VERSION-1_am
 TG_CHK="$(sha256sum telegraf_$TELEGRAF_VERSION-1_amd64.deb)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 dpkg -i telegraf_$TELEGRAF_VERSION-1_amd64.deb
@@ -153,14 +153,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -188,7 +188,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -201,7 +201,7 @@ EOF
 echo "Waiting 30 sec for nethermind to come up and create an account..."
 sleep 30
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
@@ -213,7 +213,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -221,7 +221,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -233,7 +233,7 @@ docker-compose up -d
 
 echo "Waiting 15 sec for nethermind to come up and generate the enode..."
 sleep 15
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -258,28 +258,30 @@ iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -j FILTERS
 iptables -P INPUT DROP
 
-iptables -A DOCKER-USER -i $NETIF -j FILTERS
+iptables -A DOCKER-USER -i "$NETIF" -j FILTERS
 iptables -A DOCKER-USER -j RETURN
 iptables-save > /etc/iptables/rules.v4
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
 
 # END OF MAIN
@@ -452,9 +454,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 22820000,
-    "PivotHash": "0xcda62f56b3c0bf91421446f2341bfba9e6dacafe012a7173d8e071c6a7e17bb0",
-    "PivotTotalDifficulty": "7765243613135815736234208541592950585066626012",
+    "PivotNumber": 26680000,
+    "PivotHash": "0x038403ed7351bf180066ea7b6396daec13e6bb13163334ac9fab8ee3de19d471",
+    "PivotTotalDifficulty": "9078733549450638205202834526279575881277928465",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -487,6 +489,12 @@ cat > configs/volta.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/volta-affiliate/nethermind/install-validator-oracle-8.x-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-oracle-8.x-volta.sh
@@ -6,8 +6,8 @@ set -o errexit
 export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.21.1"
-NETHERMIND_CHKSUM="sha256:63f626f9c008ffb4f49cc8b0078234ece5ff7f60599957c41633c8575dbf8984"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -257,8 +257,8 @@ service iptables save
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
@@ -448,9 +448,9 @@ cat > configs/volta.cfg << EOF
   },
   "Sync": {
     "FastSync": true,
-    "PivotNumber": 23470000,
-    "PivotHash": "0x170855d91477b9b0697f60a8fefdfed7f5c3fc36593fd0bd4e81f0028d815f46",
-    "PivotTotalDifficulty": "7986427151634425737485402036423599922511582537",
+    "PivotNumber": 26680000,
+    "PivotHash": "0x038403ed7351bf180066ea7b6396daec13e6bb13163334ac9fab8ee3de19d471",
+    "PivotTotalDifficulty": "9078733549450638205202834526279575881277928465",
     "FastBlocks" : true,
     "UseGethLimitsInFastBlocks" : false,
     "FastSyncCatchUpHeightDelta": 10000000000
@@ -483,6 +483,12 @@ cat > configs/volta.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF

--- a/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
+++ b/volta-affiliate/nethermind/install-validator-ubuntu-server-18.04-volta.sh
@@ -3,11 +3,11 @@
 # Make the script exit on any error
 set -e
 set -o errexit
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # Configuration Block - Docker checksums are the image Id
-export NETHERMIND_VERSION="nethermind/nethermind:1.18.0"
-NETHERMIND_CHKSUM="sha256:1af26d435842dfd830f1f59823e4f368cf3472666afe8e7cc893e5cadcb298fb"
+export NETHERMIND_VERSION="nethermind/nethermind:1.25.4"
+NETHERMIND_CHKSUM="sha256:ca1dbaf99121965397294f225ebb0c1100925cce42a5ce38961e4fd9383e1539"
 
 export NETHERMINDTELEMETRY_VERSION="1.0.1"
 NETHERMINDTELEMETRY_CHKSUM="sha256:1aa2fc9200acdd7762984416b634077522e5f1198efef141c0bbdb112141bf6d"
@@ -49,13 +49,13 @@ apt-get install -y curl net-tools dnsutils expect jq iptables-persistent debsums
 
 # Get external IP
 if EXTERNAL_IP=$(curl --fail -s -m 2 http://ipv4.icanhazip.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://checkip.amazonaws.com); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://ipinfo.io/ip); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 elif EXTERNAL_IP=$(curl --fail -s -m 2 http://api.ipify.org); then
-    echo Public IP: $EXTERNAL_IP
+    echo Public IP: "$EXTERNAL_IP"
 else
     echo Failed while detecting public IP address
 fi;
@@ -71,7 +71,7 @@ until [[ -n "$COMPANY_NAME" ]]; do
 	      COMPANY_NAME=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter Affiliate/Company Name (will be cut to 30 chars)" 8 78 $COMPANY_NAME --title "Node Configuration" 3>&1 1>&2 2>&3)
         exitstatus=$?
         if [[ $exitstatus = 0 ]]; then
-                echo "Affiliate/Company name has been set to: " $COMPANY_NAME
+                echo "Affiliate/Company name has been set to: " "$COMPANY_NAME"
         else
                 echo "User has cancelled the prompt."
                 break;
@@ -82,7 +82,7 @@ EXTERNAL_IP=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Ente
 NETIF=$(whiptail --backtitle="EWF Genesis Node Installer" --inputbox "Enter this hosts primary network interface" 8 78 $NETIF --title "Connectivity" 3>&1 1>&2 2>&3)
 fi
 
-COMPANY_NAME=$(echo $COMPANY_NAME | cut -c -30)
+COMPANY_NAME=$(echo "$COMPANY_NAME" | cut -c -30)
 
 # Declare a main function. This way we can put all other functions (especially the assert writers) to the bottom.
 main() {
@@ -126,7 +126,7 @@ wget https://dl.influxdata.com/telegraf/releases/telegraf_$TELEGRAF_VERSION-1_am
 TG_CHK="$(sha256sum telegraf_$TELEGRAF_VERSION-1_amd64.deb)"
 if [ "$TELEGRAF_CHKSUM" != "$TG_CHK" ]; then
   echo "ERROR: Unable to verify telegraf package. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 dpkg -i telegraf_$TELEGRAF_VERSION-1_amd64.deb
@@ -153,14 +153,14 @@ docker pull $NETHERMIND_VERSION
 IMGHASH="$(docker image inspect $NETHERMIND_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMIND_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 docker pull nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION
 IMGHASH="$(docker image inspect nethermindeth/nethermind-telemetry:$NETHERMINDTELEMETRY_VERSION|jq -r '.[0].Id')"
 if [ "$NETHERMINDTELEMETRY_CHKSUM" != "$IMGHASH" ]; then
   echo "ERROR: Unable to verify nethermind-telemetry docker image. Checksum missmatch."
-  exit -1;
+  exit 1;
 fi
 
 # Create the directory structure
@@ -188,7 +188,7 @@ chown 1000:1000 .secret
 mv .secret keystore/.secret
 
 docker run -d --network host --name nethermind \
-    -v ${XPATH}/keystore/:/nethermind/keystore \
+    -v "${XPATH}"/keystore/:/nethermind/keystore \
     ${NETHERMIND_VERSION} --config ${CHAINNAME} --Init.EnableUnsecuredDevWallet true --JsonRpc.Enabled true
 
 generate_account_data()
@@ -201,7 +201,7 @@ EOF
 echo "Waiting 30 sec for nethermind to come up and create an account..."
 sleep 30
 # Send request to create account from seed
-ADDR=`curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result'`
+ADDR=$(curl --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data "$(generate_account_data)" | jq -r '.result')
 
 echo "Account created: $ADDR"
 INFLUX_USER=${ADDR:2} # cutting 0x prefix
@@ -213,7 +213,7 @@ docker stop nethermind
 docker rm -f nethermind
 
 writeNethermindConfig
-NETHERMIND_KEY_FILE="$(ls -1 ./keystore/|grep UTC|tail -n1)"
+NETHERMIND_KEY_FILE=$(find ./keystore/ -maxdepth 1 -type f -name 'UTC*' -printf '%T@ %p\n' | sort -n | tail -n1 | awk '{print $NF}')
 
 # Prepare nethermind telemetry pipe
 mkfifo /var/spool/nethermind.sock
@@ -221,7 +221,7 @@ chown telegraf /var/spool/nethermind.sock
 
 # Write NLog config file
 wget $NLOG_CONFIG -O NLog.config
-setJsonRpcLogsLevelToError
+# setJsonRpcLogsLevelToError
 
 # Write the docker-compose file to disk
 writeDockerCompose
@@ -233,7 +233,7 @@ docker-compose up -d
 
 echo "Waiting 15 sec for nethermind to come up and generate the enode..."
 sleep 15
-ENODE=`curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result'`
+ENODE=$(curl -s --request POST --url http://localhost:8545/ --header 'content-type: application/json' --data '{ "method": "net_localEnode", "params": [], "id": 1, "jsonrpc": "2.0" }' | jq -r '.result')
 
 # Now all information is complete to write the telegraf file
 writeTelegrafConfig
@@ -258,30 +258,31 @@ iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -j FILTERS
 iptables -P INPUT DROP
 
-iptables -A DOCKER-USER -i $NETIF -j FILTERS
+iptables -A DOCKER-USER -i "$NETIF" -j FILTERS
 iptables -A DOCKER-USER -j RETURN
 iptables-save > /etc/iptables/rules.v4
 
 # run automated post-install audit
 cd /opt/
-wget https://downloads.cisofy.com/lynis/lynis-2.7.1.tar.gz
-tar xvzf lynis-2.7.1.tar.gz
+wget https://downloads.cisofy.com/lynis/lynis-3.1.0.tar.gz
+tar xvzf lynis-3.1.0.tar.gz
 mv lynis /usr/local/
 ln -s /usr/local/lynis/lynis /usr/bin/lynis
 lynis audit system
 
 
 # Print install summary
-cd $HOMEDIR
-echo "==== EWF Affiliate Node Install Summary ====" > install-summary.txt
-echo "Company: $COMPANY_NAME" >> install-summary.txt
-echo "Validator Address: $ADDR" >> install-summary.txt
-echo "Enode: $ENODE" >> install-summary.txt
-echo "IP Address: $EXTERNAL_IP" >> install-summary.txt
-echo "InfluxDB Username: $INFLUX_USER" >> install-summary.txt
-echo "InfluxDB Password: $INFLUX_PASS" >> install-summary.txt
+cd "$HOMEDIR" || exit 1
+{
+  echo "==== EWF Affiliate Node Install Summary ===="
+  echo "Company: ${COMPANY_NAME}"
+  echo "Validator Address: ${ADDR}"
+  echo "Enode: ${ENODE}"
+  echo "IP Address: ${EXTERNAL_IP}"
+  echo "InfluxDB Username: ${INFLUX_USER}"
+  echo "InfluxDB Password: ${INFLUX_PASS}"
+} > install-summary.txt
 cat install-summary.txt
-
 
 # END OF MAIN
 }
@@ -488,6 +489,12 @@ cat > configs/volta.cfg << EOF
   },
   "Aura": {
     "ForceSealing": true
+  },
+  "Mining": {
+    "MinGasPrice": 1
+  },
+  "Merge": {
+    "Enabled": false
   }
 }
 EOF


### PR DESCRIPTION
- Update nethermind version v1.25.4 in validator script
- Update lynis package version as v2.7.x is achieved.
  - https://downloads.cisofy.com/lynis/
  - https://downloads.cisofy.com/lynis/archive/
- Minor improvement of scripts.
- Tested in Debian 12
```
  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /usr/local/lynis/default.prf for all settings)

==== EWF Affiliate Node Install Summary ====
Company: test-neth-val-deb
Validator Address: 0x0bae863e2569409c639b62c60578b9da39cbdf0d
Enode: enode://602f1b8b53da547333b0cd617fdcd5836bc8f4e72361442a411db6ef1f028994b68572f9b4f597d163cbcdc5b3eecd1a0d2fb7dc34bc6c6aeb36a2bfdda7c567@35.180.134.193:30303
IP Address: 35.180.134.193
InfluxDB Username: 0bae863e2569409c639b62c60578b9da39cbdf0d
InfluxDB Password: f6472a422df2b8cc41b829e49e0912d3
admin@ip-172-31-11-145:~$ ls
docker-stack  install-summary.txt  install-val.sh
admin@ip-172-31-11-145:~$ cat install-summary.txt 
==== EWF Affiliate Node Install Summary ====
Company: test-neth-val-deb
Validator Address: 0x0bae863e2569409c639b62c60578b9da39cbdf0d
Enode: enode://602f1b8b53da547333b0cd617fdcd5836bc8f4e72361442a411db6ef1f028994b68572f9b4f597d163cbcdc5b3eecd1a0d2fb7dc34bc6c6aeb36a2bfdda7c567@35.180.134.193:30303
IP Address: 35.180.134.193
InfluxDB Username: 0bae863e2569409c639b62c60578b9da39cbdf0d
InfluxDB Password: f6472a422df2b8cc41b829e49e0912d3
```

```
nethermind_1            | 28 Aug 16:39:15 | Waiting for peers... 5s 
nethermind_1            | 28 Aug 16:39:19 | Changing state Disconnected to FastHeaders at processed: 0 | state: 0 | block: 0 | header: 0 | target block: 31585664 | peer block: 31585664 
nethermind_1            | 28 Aug 16:39:19 | Sync mode changed from Disconnected to FastHeaders 
nethermind_1            | 28 Aug 16:39:20 | Old Headers       6,656 / 26,940,000 (  0.02 %) | queue         0 | current            0 Blk/s | total        6,634 Blk/s 
nethermind_1            | 28 Aug 16:39:20 | Changing state FastHeaders to FastSync, FastHeaders at processed: 0 | state: 0 | block: 0 | header: 26940000 | target block: 31585664 | peer block: 31585664 
nethermind_1            | 28 Aug 16:39:20 | Sync mode changed from FastHeaders to FastSync, FastHeaders 
nethermind_1            | 28 Aug 16:39:25 | Old Headers       7,168 / 26,940,000 (  0.03 %) | queue         0 | current          102 Blk/s | total        1,194 Blk/s 
nethermind_1            | 28 Aug 16:39:25 | Downloaded   26,941,653 / 31,585,665 ( 85.30 %) | current            0 Blk/s | total          362 Blk/s 
nethermind_1            | 28 Aug 16:39:30 | Old Headers       7,168 / 26,940,000 (  0.03 %) | queue         0 | current            0 Blk/s | total          651 Blk/s 
nethermind_1            | 28 Aug 16:39:30 | Downloaded   26,943,939 / 31,585,666 ( 85.30 %) | current          457 Blk/s | total          412 Blk/s 
nethermind_1            | 28 Aug 16:39:30 | Discovered new block 31585667 16:39:30 (0x251902...efb89e), tx count: 0 miner 0x8e92b0080b33c9b0f84d29f558cdb96eb7719981, sent by [Peer|eth66|31585667|   206.81.19.94:30303| Out], with AuRa step 344972634 
nethermind_1            | 28 Aug 16:39:35 | Old Headers       7,168 / 26,940,000 (  0.03 %) | queue         0 | current            0 Blk/s | total          448 Blk/s 
nethermind_1            | 28 Aug 16:39:35 | Downloaded   26,946,225 / 31,585,667 ( 85.31 %) | current          457 Blk/s | total          428 Blk/s 
nethermind_1            | 28 Aug 16:39:40 | Discovered new block 31585668 16:39:40 (0xd083e0...b973f0), tx count: 0 miner 0x68e2bdba5da0793cf9031e1364a22b18ef707949, sent by [Peer|eth66|31585668|   206.81.19.94:30303| Out], with AuRa step 344972636 
nethermind_1            | 28 Aug 16:39:40 | Old Headers       7,168 / 26,940,000 (  0.03 %) | queue         0 | current            0 Blk/s | total          341 Blk/s 
nethermind_1            | 28 Aug 16:39:40 | Downloaded   26,948,384 / 31,585,668 ( 85.32 %) | current          432 Blk/s | total          429 Blk/s 

```